### PR TITLE
Add option to disable text highlighting

### DIFF
--- a/__tests__/config.ts
+++ b/__tests__/config.ts
@@ -113,6 +113,7 @@ describe('Config', () => {
       toggleDefinition: ['d'],
       nextDictionary: ['Shift', 'Enter'],
     });
+    expect(config.noTextHighlight).toEqual(false);
     expect(config.showKanjiComponents).toEqual(true);
     expect(config.kanjiReferences).toEqual({
       H: true,

--- a/extension/options.html
+++ b/extension/options.html
@@ -20,6 +20,11 @@
           <label for=readingOnly>Hide definitions and show only
             reading</label>
         </div>
+        <div class="panel-section panel-section-formElements browser-style">
+          <input type=checkbox id=noTextHighlight name=noTextHighlight
+          class="panel-formElements-item">
+          <label for=noTextHighlight>Disable text highlighting</label>
+        </div>
         <div class="panel-section panel-section-header">
           <div class=text-section-header>Keyboard</div>
         </div>

--- a/src/common.d.ts
+++ b/src/common.d.ts
@@ -19,6 +19,9 @@ interface ContentConfig {
   // by KeyboardEvent.key). The array may be empty in which case the action is
   // not possible via keyboard.
   keys: KeyboardKeys;
+
+  // Prevents highlighting text on hover
+  noTextHighlight: boolean;
 }
 
 declare const enum DictMode {

--- a/src/config.ts
+++ b/src/config.ts
@@ -15,6 +15,7 @@ type KanjiReferenceFlags = { [abbrev: string]: boolean };
 interface Settings {
   readingOnly?: boolean;
   keys?: KeyboardKeys;
+  noTextHighlight?: boolean;
   showKanjiComponents?: boolean;
   kanjiReferences?: KanjiReferenceFlags;
 }
@@ -113,6 +114,24 @@ class Config {
     browser.storage.sync.set({ keys: this._settings.keys });
   }
 
+  // noTextHighlight: Defaults to false
+
+  get noTextHighlight(): boolean {
+    return !!this._settings.noTextHighlight;
+  }
+
+  set noTextHighlight(value: boolean) {
+    if (
+      typeof this._settings.noTextHighlight !== 'undefined' &&
+      this._settings.noTextHighlight === value
+    ) {
+      return;
+    }
+
+    this._settings.noTextHighlight = value;
+    browser.storage.sync.set({ noTextHighlight: value });
+  }
+
   // showKanjiComponents: Defaults to true
 
   get showKanjiComponents(): boolean {
@@ -155,6 +174,7 @@ class Config {
     return {
       readingOnly: this.readingOnly,
       keys: this.keys,
+      noTextHighlight: this.noTextHighlight,
     };
   }
 }

--- a/src/options.ts
+++ b/src/options.ts
@@ -9,6 +9,7 @@ async function fillVals() {
 
   const optform = document.getElementById('optform') as HTMLFormElement;
   optform.readingOnly.checked = config.readingOnly;
+  optform.noTextHighlight.checked = config.noTextHighlight;
   optform.showKanjiComponents.checked = config.showKanjiComponents;
 
   for (const [abbrev, setting] of Object.entries(config.kanjiReferences)) {
@@ -31,6 +32,10 @@ document.getElementById('readingOnly').addEventListener('click', evt => {
   config.readingOnly = (evt.target as HTMLInputElement).checked;
 });
 
+document.getElementById('noTextHighlight').addEventListener('click', evt => {
+  config.noTextHighlight = (evt.target as HTMLInputElement).checked;
+});
+
 document
   .getElementById('showKanjiComponents')
   .addEventListener('click', evt => {
@@ -40,7 +45,7 @@ document
 for (const ref of Object.keys(config.kanjiReferences)) {
   document.getElementById(ref).addEventListener('click', evt => {
     config.updateKanjiReferences({
-      [ref]: (evt.target as HTMLInputElement).checked
+      [ref]: (evt.target as HTMLInputElement).checked,
     });
   });
 }

--- a/src/rikaicontent.ts
+++ b/src/rikaicontent.ts
@@ -763,6 +763,10 @@ class RikaiContent {
     // TODO: Record when the mouse is down and don't highlight in that case
     //       (I guess that would interfere with selecting)
 
+    if (this._config.noTextHighlight) {
+      return;
+    }
+
     this._selectedWindow =
       textAtPoint.rangeStart.container.ownerDocument.defaultView;
 


### PR DESCRIPTION
Fixes #5.

It worked before the custom keys commits happen (which then stuff explodes after rebasing and running `prepare`).

I couldn't run master either, so ┐(ಠ_ಠ)┌

```
src/config.ts(113,30): error TS2345: Argument of type '{ keys: KeyboardKeys; }' is not assignable to parameter of type 'StorageObject'.
  Property 'keys' is incompatible with index signature.
    Type 'KeyboardKeys' is not assignable to type 'StorageValue'.
      Type 'KeyboardKeys' is not assignable to type 'StorageSet'.
        Property '[Symbol.toStringTag]' is missing in type 'KeyboardKeys'.
```