### PR TITLE
Add lang attribute to popup window

### DIFF
--- a/src/content.ts
+++ b/src/content.ts
@@ -1610,7 +1610,7 @@ export class RikaiContent {
       // Add the popup div
       const popup = doc.createElement('div');
       popup.setAttribute('id', 'rikaichamp-window');
-      popup.setAttribute('lang', 'ja-JP');
+      popup.setAttribute('lang', 'ja');
       popup.classList.add(`-${this._config.popupStyle}`);
       doc.documentElement.append(popup);
 

--- a/src/content.ts
+++ b/src/content.ts
@@ -1610,6 +1610,7 @@ export class RikaiContent {
       // Add the popup div
       const popup = doc.createElement('div');
       popup.setAttribute('id', 'rikaichamp-window');
+      popup.setAttribute('lang', 'ja-JP');
       popup.classList.add(`-${this._config.popupStyle}`);
       doc.documentElement.append(popup);
 


### PR DESCRIPTION
When I was visiting a website with body lang='zh-CN', I found that the rikaichamp popup window is also using the Chinese fontface, which is weird.
So I think it'll be nice to have a lang='ja-JP' for the popup.