### PR TITLE
Deinflect for i-adj ending in き preceding nouns

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -248,6 +248,9 @@
   "deinflect_imperative_negative": {
     "message": "imperative negative"
   },
+  "deinflect_ki": {
+    "message": "-ki"
+  },
   "deinflect_masu_stem": {
     "message": "masu stem"
   },

--- a/_locales/ja/messages.json
+++ b/_locales/ja/messages.json
@@ -251,6 +251,9 @@
   "deinflect_imperative_negative": {
     "message": "否定命令形"
   },
+  "deinflect_ki": {
+    "message": "連体形"
+  },
   "deinflect_masu_stem": {
     "message": "連用形"
   },

--- a/_locales/zh_hans/messages.json
+++ b/_locales/zh_hans/messages.json
@@ -248,6 +248,9 @@
   "deinflect_imperative_negative": {
     "message": "否定命令形"
   },
+  "deinflect_ki": {
+    "message": "连体形"
+  },
   "deinflect_masu_stem": {
     "message": "连用形"
   },

--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,8 @@
 ## 0.3.2 (not yet released)
 
-(Nothing yet)
+- Added support for recognizing き inflection of i-adjectives
+  thanks to [@SaltfishAmi](https://github.com/SaltfishAmi)
+  ([#435](https://github.com/birtles/rikaichamp/issues/435)).
 
 ## 0.3.1 (2020-11-26)
 

--- a/src/data.ts
+++ b/src/data.ts
@@ -66,7 +66,7 @@ interface DictionaryOptions {
   bugsnag?: BugsnagClient;
 }
 
-const enum WordType {
+export const enum WordType {
   IchidanVerb = 1 << 0, // i.e. ru-verbs
   GodanVerb = 1 << 1, // i.e. u-verbs
   IAdj = 1 << 2,

--- a/src/deinflect.test.ts
+++ b/src/deinflect.test.ts
@@ -1,4 +1,5 @@
 import { deinflect, DeinflectReason } from './deinflect';
+import { WordType } from './data';
 
 describe('deinflect', () => {
   it('performs de-inflection', () => {
@@ -79,6 +80,16 @@ describe('deinflect', () => {
     });
   });
 
+  it('deinflects ki ending for i-adj', () => {
+    const result = deinflect('美しき');
+    const match = result.find((candidate) => candidate.word === '美しい');
+    expect(match).toEqual({
+      reasons: [[DeinflectReason.Ki]],
+      type: WordType.IAdj,
+      word: '美しい',
+    });
+  });
+
   it('deinflects irregular forms of 行く', () => {
     const cases = [
       ['行った', '行く', DeinflectReason.Past, 2],
@@ -141,12 +152,9 @@ describe('deinflect', () => {
   });
 
   it('deinflects the continuous form', () => {
-    const cases: Array<[
-      string,
-      string,
-      number,
-      Array<DeinflectReason> | undefined
-    ]> = [
+    const cases: Array<
+      [string, string, number, Array<DeinflectReason> | undefined]
+    > = [
       // U-verbs
       ['戻っている', '戻る', 2, undefined],
       ['戻ってる', '戻る', 2, undefined],

--- a/src/deinflect.ts
+++ b/src/deinflect.ts
@@ -29,6 +29,7 @@ export const enum DeinflectReason {
   Noun,
   ImperativeNegative,
   Continuous,
+  Ki,
 }
 
 export const deinflectL10NKeys: { [key: number]: string } = {
@@ -62,11 +63,22 @@ export const deinflectL10NKeys: { [key: number]: string } = {
   [DeinflectReason.Noun]: 'deinflect_noun',
   [DeinflectReason.ImperativeNegative]: 'deinflect_imperative_negative',
   [DeinflectReason.Continuous]: 'deinflect_continuous',
+  [DeinflectReason.Ki]: 'deinflect_ki',
 };
 
 const deinflectRuleData: Array<[string, string, number, number]> = [
-  ['いらっしゃいませんでした', 'いらっしゃる', 640, DeinflectReason.PolitePastNegative],
-  ['おっしゃいませんでした', 'おっしゃる', 640, DeinflectReason.PolitePastNegative],
+  [
+    'いらっしゃいませんでした',
+    'いらっしゃる',
+    640,
+    DeinflectReason.PolitePastNegative,
+  ],
+  [
+    'おっしゃいませんでした',
+    'おっしゃる',
+    640,
+    DeinflectReason.PolitePastNegative,
+  ],
   ['いらっしゃいました', 'いらっしゃる', 640, DeinflectReason.PolitePast],
   ['くありませんでした', 'い', 1152, DeinflectReason.PolitePastNegative],
   ['いらっしゃいます', 'いらっしゃる', 640, DeinflectReason.Polite],
@@ -500,6 +512,7 @@ const deinflectRuleData: Array<[string, string, number, number]> = [
   ['き', 'くる', 2176, DeinflectReason.MasuStem],
   ['ぎ', 'ぎる', 384, DeinflectReason.MasuStem],
   ['ぎ', 'ぐ', 640, DeinflectReason.MasuStem],
+  ['き', 'い', 1152, DeinflectReason.Ki],
   ['く', 'い', 1152, DeinflectReason.Adv],
   ['け', 'く', 640, DeinflectReason.Imperative],
   ['け', 'ける', 384, DeinflectReason.MasuStem],


### PR DESCRIPTION
issue #435 , like this: 美しきあの人. Technically it's not modern grammar but I think this is quite frequent.

BTW, I did nothing to the first two entries in `deinflectRuleData`; it's done automatically by the naughty `prettier --write`.