### PR TITLE
Localize meta tags for kanji, i.e. 'kokuji' and 'phantom kanji'

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -129,6 +129,14 @@
       }
     }
   },
+  "content_kanji_meta_kokuji": {
+    "message": "kokuji",
+    "description": "Meta label for kokuji (kanji originated in Japan)"
+  },
+  "content_kanji_meta_phantom_kanji": {
+    "message": "phantom kanji",
+    "description": "Meta label for phantom kanji/ghost characters"
+  },
   "content_kanji_nanori_label": {
     "message": "Names (名乗り)",
     "description": "Label given to name readings"

--- a/_locales/ja/messages.json
+++ b/_locales/ja/messages.json
@@ -129,6 +129,14 @@
       }
     }
   },
+  "content_kanji_meta_kokuji": {
+    "message": "国字",
+    "description": "Meta label for kokuji (kanji originated in Japan)"
+  },
+  "content_kanji_meta_phantom_kanji": {
+    "message": "幽霊文字",
+    "description": "Meta label for phantom kanji/ghost characters"
+  },
   "content_kanji_nanori_label": {
     "message": "名乗り",
     "description": "Label given to name readings"

--- a/_locales/zh_hans/messages.json
+++ b/_locales/zh_hans/messages.json
@@ -129,6 +129,14 @@
       }
     }
   },
+  "content_kanji_meta_kokuji": {
+    "message": "国字",
+    "description": "Meta label for kokuji (kanji originated in Japan)"
+  },
+  "content_kanji_meta_phantom_kanji": {
+    "message": "幽灵汉字",
+    "description": "Meta label for phantom kanji/ghost characters"
+  },
   "content_kanji_nanori_label": {
     "message": "人名读法",
     "description": "Label given to name readings"

--- a/src/popup.ts
+++ b/src/popup.ts
@@ -977,8 +977,10 @@ function renderMeta(meta: Array<string>): HTMLElement {
   for (const tag of meta) {
     const span = document.createElement('span');
     span.classList.add('tag');
-    span.lang = 'en';
-    span.textContent = tag;
+    span.lang = getLangTag();
+    span.textContent = browser.i18n.getMessage(
+      `content_kanji_meta_${tag.replace(' ', '_')}`
+    );
     metaDiv.append(span);
   }
 


### PR DESCRIPTION
They was displayed as-is, i.e. in English, and had a hardcoded `lang='en'`.