### PR TITLE
Reconsider the meaning of "obsc" in Chinese translation

### DIFF
--- a/_locales/zh_hans/messages.json
+++ b/_locales/zh_hans/messages.json
@@ -1116,7 +1116,7 @@
     "description": "Label used to describe senses with the 'obs' (obsolete) annotation"
   },
   "misc_label_obsc": {
-    "message": "不明",
+    "message": "难懂",
     "description": "Label used to describe senses with the 'obsc' (obscure) annotation"
   },
   "misc_label_on-mim": {

--- a/_locales/zh_hans/messages.json
+++ b/_locales/zh_hans/messages.json
@@ -1116,7 +1116,7 @@
     "description": "Label used to describe senses with the 'obs' (obsolete) annotation"
   },
   "misc_label_obsc": {
-    "message": "难懂",
+    "message": "生僻",
     "description": "Label used to describe senses with the 'obsc' (obscure) annotation"
   },
   "misc_label_on-mim": {


### PR DESCRIPTION
The current translation of `obsc` itself seems 'obsc' to me.
Well, my own fault for copying the keys from Japanese locale :(

I suggest changing the translation in Japanese locale to `難解` also.