### PR TITLE
Fix projectOwner for all-contributor

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -1,6 +1,6 @@
 {
   "projectName": "rikaichamp",
-  "projectOwner": "Brian Birtles",
+  "projectOwner": "birtles",
   "repoType": "github",
   "repoHost": "https://github.com",
   "files": [


### PR DESCRIPTION
https://github.com/all-contributors/all-contributors-cli/blob/f1a336d9f3e4a63c6ce69752ffa61d67e308fa4d/src/repo/index.js#L12
```
    linkToCommits:
      '<%= options.repoHost || "https://github.com" %>/<%= options.projectOwner %>/<%= options.projectName %>/commits?author=<%= contributor.login %>',
```

↑ According to this code, ```projectOwner``` need to be the github user name in order to form a valid link.